### PR TITLE
feat: add verified proof entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -21,5 +21,7 @@ type Member @entity {
 type VerifiedProof @entity {
     id: ID!
     signal: Bytes!
+    index: Int!
+    timestamp: BigInt!
     group: Group!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -7,11 +7,19 @@ type Group @entity {
     numberOfLeaves: Int!
     admin: Bytes!
     members: [Member!]! @derivedFrom(field: "group")
+    verifiedProofsCount: Int!
+    verifiedProofs: [VerifiedProof!]! @derivedFrom(field: "group")
 }
 
 type Member @entity {
     id: ID!
     identityCommitment: BigInt!
     index: Int!
+    group: Group!
+}
+
+type VerifiedProof @entity {
+    id: ID!
+    signal: Bytes!
     group: Group!
 }

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -133,9 +133,10 @@ export function addVerifiedProof(event: ProofVerified): void {
     const group = Group.load(event.params.groupId.toString())
     if (!group) return;
 
+    const proofIndex = group.verifiedProofsCount;
     const verifiedProofId = hash(
         concat(
-            ByteArray.fromI32(group.verifiedProofsCount),
+            ByteArray.fromI32(proofIndex),
             concat(event.params.signal,ByteArray. fromBigInt(event.params.groupId))
         )
     );
@@ -148,6 +149,8 @@ export function addVerifiedProof(event: ProofVerified): void {
     )
 
     verifiedProof.signal = event.params.signal;
+    verifiedProof.timestamp = event.block.timestamp;
+    verifiedProof.index = proofIndex;
     verifiedProof.group = group.id;
 
     verifiedProof.save();

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -18,7 +18,7 @@ export function createGroup(event: GroupCreated): void {
     group.zeroValue = event.params.zeroValue
     group.size = 0
     group.numberOfLeaves = 0
-    group.verifiedProofsCount = 0;
+    group.verifiedProofsCount = 0
 
     group.save()
 
@@ -133,9 +133,11 @@ export function addVerifiedProof(event: ProofVerified): void {
     const group = Group.load(event.params.groupId.toString())
     if (!group) return;
 
-    const proofIndex = group.verifiedProofsCount;
     const verifiedProofId = hash(
-        concat(ByteArray.fromI32(proofIndex), ByteArray.fromBigInt(event.params.groupId))
+        concat(
+            ByteArray.fromI32(group.verifiedProofsCount),
+            concat(event.params.signal,ByteArray. fromBigInt(event.params.groupId))
+        )
     );
 
     const  verifiedProof = new VerifiedProof(verifiedProofId);

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -1,5 +1,11 @@
 import { ByteArray, log } from "@graphprotocol/graph-ts"
-import { GroupAdminUpdated, GroupCreated, MemberAdded, MemberRemoved, ProofVerified } from "../generated/Semaphore/Semaphore"
+import {
+    GroupAdminUpdated,
+    GroupCreated,
+    MemberAdded,
+    MemberRemoved,
+    ProofVerified
+} from "../generated/Semaphore/Semaphore"
 import { Member, Group, VerifiedProof } from "../generated/schema"
 import { concat, hash } from "./utils"
 
@@ -131,35 +137,32 @@ export function addVerifiedProof(event: ProofVerified): void {
     log.debug(`ProofVerified event block {}`, [event.block.number.toString()])
 
     const group = Group.load(event.params.groupId.toString())
-    if (!group) return;
+    if (!group) return
 
-    const proofIndex = group.verifiedProofsCount;
+    const proofIndex = group.verifiedProofsCount
     const verifiedProofId = hash(
-        concat(
-            ByteArray.fromI32(proofIndex),
-            concat(event.params.signal,ByteArray. fromBigInt(event.params.groupId))
-        )
-    );
-
-    const  verifiedProof = new VerifiedProof(verifiedProofId);
-
-    log.info(
-        "Adding verified proof with signal '{}' in the onchain group '{}'",
-        [event.params.signal.toHexString(), event.params.groupId.toString()]
+        concat(ByteArray.fromI32(proofIndex), concat(event.params.signal, ByteArray.fromBigInt(event.params.groupId)))
     )
 
-    verifiedProof.signal = event.params.signal;
-    verifiedProof.timestamp = event.block.timestamp;
-    verifiedProof.index = proofIndex;
-    verifiedProof.group = group.id;
+    const verifiedProof = new VerifiedProof(verifiedProofId)
 
-    verifiedProof.save();
+    log.info("Adding verified proof with signal '{}' in the onchain group '{}'", [
+        event.params.signal.toHexString(),
+        event.params.groupId.toString()
+    ])
 
-    group.verifiedProofsCount += 1;
-    group.save();
+    verifiedProof.signal = event.params.signal
+    verifiedProof.timestamp = event.block.timestamp
+    verifiedProof.index = proofIndex
+    verifiedProof.group = group.id
 
-    log.info(
-        "Verified proof with signal '{}' in the onchain group '{}' has been added",
-        [event.params.signal.toHexString(), event.params.groupId.toString()]
-    )
+    verifiedProof.save()
+
+    group.verifiedProofsCount += 1
+    group.save()
+
+    log.info("Verified proof with signal '{}' in the onchain group '{}' has been added", [
+        event.params.signal.toHexString(),
+        event.params.groupId.toString()
+    ])
 }

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -30,4 +30,6 @@ dataSources:
                 handler: addMember
               - event: MemberRemoved(indexed uint256,uint256,uint256)
                 handler: removeMember
+              - event: ProofVerified(indexed uint256,bytes32)
+                handler: addVerifiedProof
           file: ./src/mapping.ts


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

### Schema updates

The entity `VerifiedProof` has been added to the schema, its fields are organised as follows:
- `id`: hash of concatenation of signal, proof index and group ID,
- `signal`: the signal of the proof,
- `index`: the proof index,
- `timestamp`: the block timestamp of the associated transaction receipt.

The proof index is defined as an integer starting from 0, every time a new proof has been verified in the group, the index is increased by 1. Its goal is to allow the ordering of the signals.

The `Group` entity has been updated, new fields have been added:
- `verifiedProofsCount`: the number of verified proofs for this group,
- `verifiedProofs`: the array of verified proofs for this group. This field is derived from the `VerifiedProof` entities.

### Handlers updates

The initialisation of the group has been updated in order to initialise the `verifiedProofsCount` to `0` in a new group.

The handler for `ProofVerified` has been added, it inserts a new `VerifiedProofEntity` and increases the `verifiedProofsCount` of the related group.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #1 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
