### PR TITLE
Add setup for local subgraph deployment/testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,37 @@ yarn deploy:goerli semaphore-protocol/goerli-5259d3
 // or
 yarn deploy:arbitrum semaphore-protocol/arbitrum-86337c
 ```
+
+<br/>
+
+## Local Development
+
+This is a guide to run TheGraph node locally and build subgraphs based on events from local Ethereum network (like hardhat).
+
+Start services required for TheGraph node by running
+
+```sh
+docker-compose -f docker-compose-graph.yml up
+```
+
+Start local hardhat node and deploy Sempahore contract
+
+```sh
+# CWD = /semaphore/packages/contracts
+npx hardhat node
+yarn deploy:semaphore --network localhost
+```
+
+You can now set the deployed contract address in the subgraph.yaml file. Make sure the network is set as `localhost`.
+
+Once subgraph is ready to be published, run the below command to push it to the local TheGraph node
+
+```sh
+yarn deploy-local
+```
+
+Once the subgraph is published it will start indexing. You can query the subgraph using the GraphQL endpoint:
+
+```
+http://127.0.0.1:8000/subgraphs/name/sempahore/graphql
+```

--- a/docker-compose-graph.yml
+++ b/docker-compose-graph.yml
@@ -1,0 +1,59 @@
+version: "3.9"
+
+services:
+    graph-node:
+        image: graphprotocol/graph-node
+        ports:
+            - "8000:8000"
+            - "8001:8001"
+            - "8020:8020"
+            - "8030:8030"
+            - "8040:8040"
+        depends_on:
+            - ipfs
+            - postgres
+        environment:
+            postgres_host: postgres
+            postgres_user: graph-node
+            postgres_pass: let-me-in
+            postgres_db: graph-node
+            postgres_port: 5432
+            ipfs: "ipfs:5001"
+            ethereum: "localhost:http://host.docker.internal:8545" # Should use the `localhost` as network name in subgraph.yml
+            # ethereum: 'goerli:https://goerli.infura.io/v3/YOUR-API-KEY'
+            GRAPH_LOG: info
+            GRAPH_ALLOW_NON_DETERMINISTIC_IPFS: 1
+        networks:
+            - the-graph
+
+    ipfs:
+        image: ipfs/go-ipfs:v0.4.23
+        ports:
+            - "5001:5001"
+        volumes:
+            - ipfs:/data/ipfs
+        networks:
+            - the-graph
+
+    postgres:
+        image: postgres
+        ports:
+            - "5433:5432"
+        command: ["postgres", "-cshared_preload_libraries=pg_stat_statements"]
+        environment:
+            POSTGRES_USER: graph-node
+            POSTGRES_PASSWORD: let-me-in
+            POSTGRES_DB: graph-node
+        networks:
+            - the-graph
+        volumes:
+            - postgres:/var/lib/postgresql/data
+
+networks:
+    the-graph:
+        internal: false
+        driver: bridge
+
+volumes:
+    postgres:
+    ipfs:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
         "prepare:arbitrum": "mustache config/arbitrum.json subgraph.template.yaml > subgraph.yaml",
         "deploy:goerli": "yarn prepare:goerli && yarn codegen && graph deploy --product hosted-service",
         "deploy:arbitrum": "yarn prepare:arbitrum && yarn codegen && graph deploy --product hosted-service",
+        "create-local": "graph create sempahore --node http://127.0.0.1:8020",
+        "deploy-local": "npm run create-local && graph deploy sempahore --ipfs http://localhost:5001 --node http://127.0.0.1:8020",
         "lint": "eslint . --ext .js,.ts",
         "prettier": "prettier -c .",
         "prettier:write": "prettier -w .",


### PR DESCRIPTION
## Description

Add setup and instruction for running TheGraph node locally and deploying subgraphs to local node

## Related Issue

https://github.com/semaphore-protocol/boilerplate/issues/26

## Does this introduce a breaking change?

-   [ ] Yes
-   [ ] No
